### PR TITLE
MODがONの状態で言語設定を変更するとエラーログが出る

### DIFF
--- a/Mod_Lang_JA/Mod_Lang_JA.cs
+++ b/Mod_Lang_JA/Mod_Lang_JA.cs
@@ -22,6 +22,8 @@ namespace Mod_Lang_JA
 	{
 		private string locale_name = "ja";
 
+        private bool initialized;
+
 		//
 		//the following OS detect code is referring http://stackoverflow.com/questions/10138040/how-to-detect-properly-windows-linux-mac-operating-systems
 		//
@@ -188,7 +190,11 @@ namespace Mod_Lang_JA
 		{
 			get
 			{
-				CopyLocaleAndReloadLocaleManager ();
+                if (!initialized)
+                {
+                    CopyLocaleAndReloadLocaleManager();
+                }
+                initialized = true;
 
 				return "Japanese localization Mod";
 			}


### PR DESCRIPTION
MODがONの状態で、言語設定を他言語から日本語に変更すると、エラーログが出ます。
アクセス中の言語ファイルを書き換えようとして権限エラーになってるみたいです。
このMODについては、ONにしなくても動作するので、ユーザーにそのように注意喚起してもいいのですが、
言語ファイルのコピーはゲーム起動時に1回だけ行うように修正してもいいかもしれないですね。
ということで、私の方で適当に修正してみましたので宜しければ取り込みお願いします。
